### PR TITLE
Fix issue on 'Table Number' and 'People Qty' on updating new order view

### DIFF
--- a/src/Controller/CartController.php
+++ b/src/Controller/CartController.php
@@ -27,14 +27,14 @@ class CartController extends AbstractController
     #[Route('/new', name: 'app_cart_new', methods: ['GET', 'POST'])]
     public function new(Request $request): Response
     {
-        $dishes = $request->getSession()->get('dishes');       
+        $dishes = $request->getSession()->get('dishes');              
 
         $form = $this->createForm(NewOrderType::class, null);
-        $form->handleRequest($request);
+        $form->handleRequest($request);        
 
-        $request->getSession()->set('data', $form->getData());
-
-        if($form->isSubmitted() && $form->isValid()) {                        
+        if($form->isSubmitted() && $form->isValid()) { 
+            $request->getSession()->set('data', $form->getData());
+                                   
             $aperitifs_qty  = $_POST['aperitifs_qty'] ?? [];
             $firsts_qty     = $_POST['firsts_qty']    ?? [];
             $seconds_qty    = $_POST['seconds_qty']   ?? [];
@@ -138,7 +138,8 @@ class CartController extends AbstractController
                 }
             }
 
-            $dishes =array_values($dishes);
+            if(isset($dishes)) $dishes = array_values($dishes);
+            
             $request->getSession()->set('dishes', $dishes);                        
         }
 

--- a/src/Form/Custom/NewOrderType.php
+++ b/src/Form/Custom/NewOrderType.php
@@ -11,13 +11,22 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class NewOrderType extends AbstractType
-{   
+{
+   private int|string $tableNumber;
+   private int|string $peopleQty;
+
+    public function __construct() 
+    {
+        $this->tableNumber = isset($_SESSION['_sf2_attributes']['data']['tableNumber']) ? $_SESSION['_sf2_attributes']['data']['tableNumber'] : "Select";
+        $this->peopleQty = isset($_SESSION['_sf2_attributes']['data']['peopleQty']) ? $_SESSION['_sf2_attributes']['data']['peopleQty'] : "Select";
+    }    
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {                
         $builder
             ->add('tableNumber', ChoiceType::class, [
                 'choices' => [
-                    'Select' => "",
+                    "{$this->tableNumber}" => "",
                     '1'      => 1,
                     '2'      => 2,
                     '3'      => 3,
@@ -32,7 +41,7 @@ class NewOrderType extends AbstractType
             ])
             ->add('peopleQty', ChoiceType::class, [
                 'choices' => [
-                    'Select' => "",
+                    "{$this->peopleQty}" => "",
                     '1'      => 1,
                     '2'      => 2,
                     '3'      => 3,
@@ -61,7 +70,7 @@ class NewOrderType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => null,            
+            'data_class' => null,                  
         ]);
     }
 }


### PR DESCRIPTION
Feature: Improve 'new order' view to show the table number and people quantity when update the form. Now if we change to another section and we come back to the 'new order' view, we can see the table number and people quantity that was selected.
- Updated src/Controller/CartController.php controller.
- Updated src/Form/Custom/NewOrderType.php form.